### PR TITLE
BookServiceTestにfindBookの単体テストを実装

### DIFF
--- a/src/main/java/com/ookawara/book/application/BookApplication.java
+++ b/src/main/java/com/ookawara/book/application/BookApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class BookApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BookApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BookApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/ookawara/book/application/entity/Book.java
+++ b/src/main/java/com/ookawara/book/application/entity/Book.java
@@ -1,5 +1,7 @@
 package com.ookawara.book.application.entity;
 
+import java.util.Objects;
+
 public class Book {
     private int book_id;
     private String name;
@@ -39,5 +41,18 @@ public class Book {
 
     public String getCategory() {
         return category;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Book book = (Book) o;
+        return book_id == book.book_id && category_id == book.category_id && Objects.equals(name, book.name) && Objects.equals(release_date, book.release_date) && Objects.equals(is_purchased, book.is_purchased) && Objects.equals(category, book.category);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(book_id, name, release_date, is_purchased, category_id, category);
     }
 }

--- a/src/main/java/com/ookawara/book/application/entity/Category.java
+++ b/src/main/java/com/ookawara/book/application/entity/Category.java
@@ -1,5 +1,7 @@
 package com.ookawara.book.application.entity;
 
+import java.util.Objects;
+
 public class Category {
     private int category_id;
     private String category;
@@ -15,5 +17,18 @@ public class Category {
 
     public String getCategory() {
         return category;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Category category1 = (Category) o;
+        return category_id == category1.category_id && Objects.equals(category, category1.category);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(category_id, category);
     }
 }

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -37,7 +37,7 @@ public interface BookMapper {
                     if (name != null) {
                         WHERE("name like concat('%',#{name},'%')");
                     }
-                    if (isPurchased != null ) {
+                    if (isPurchased != null) {
                         WHERE("is_purchased = #{isPurchased}");
                     }
                 }

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -1,6 +1,7 @@
 package com.ookawara.book.application.service;
 
 import com.ookawara.book.application.entity.Book;
+import com.ookawara.book.application.exception.BookNotFoundException;
 import com.ookawara.book.application.mapper.BookMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,8 +10,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,10 +83,16 @@ class BookServiceTest {
     public void 指定した文字を含むデータが存在しないとき空のデータを返す() {
         List<Book> allBooks = List.of(new Book[0]);
 
-        doReturn(allBooks).when(bookMapper).findBy("no"," ",null);
-        List<Book> actual = bookService.findBy("no"," ",null);
+        doReturn(allBooks).when(bookMapper).findBy("no", " ", null);
+        List<Book> actual = bookService.findBy("no", " ", null);
         assertThat(actual).isEqualTo(allBooks);
     }
 
+    @Test
+    public void 存在する本のIDを指定したときに正常に本のデータを返す() throws BookNotFoundException {
+        doReturn(Optional.of(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル"))).when(bookMapper).findByBookId(1);
 
+        Book actual = bookService.findBook(1);
+        assertThat(actual).isEqualTo(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル"));
+    }
 }

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
@@ -100,7 +99,7 @@ class BookServiceTest {
     @Test
     public void 存在しない本のIDを指定したときに例外のエラーメッセージを返す() {
         doReturn(Optional.empty()).when(bookMapper).findByBookId(0);
-        assertThatThrownBy(()->bookService.findBook(0))
+        assertThatThrownBy(() -> bookService.findBook(0))
                 .isInstanceOf(BookNotFoundException.class)
                 .hasMessage("book：" + 0 + " のデータはありません。");
     }

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 
@@ -90,9 +91,17 @@ class BookServiceTest {
 
     @Test
     public void 存在する本のIDを指定したときに正常に本のデータを返す() throws BookNotFoundException {
-        doReturn(Optional.of(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル"))).when(bookMapper).findByBookId(1);
-
+        doReturn(Optional.of(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル")))
+                .when(bookMapper).findByBookId(1);
         Book actual = bookService.findBook(1);
         assertThat(actual).isEqualTo(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル"));
+    }
+
+    @Test
+    public void 存在しない本のIDを指定したときに例外のエラーメッセージを返す() {
+        doReturn(Optional.empty()).when(bookMapper).findByBookId(0);
+        assertThatThrownBy(()->bookService.findBook(0))
+                .isInstanceOf(BookNotFoundException.class)
+                .hasMessage("book：" + 0 + " のデータはありません。");
     }
 }


### PR DESCRIPTION
# 概要
findBookメソッドの単体テストを実装しようとしています。

# 質問内容
## やりたいこと
「存在する本のIDを指定した時に正常に本のデータを返す」というテストを成功させたい。

## 試したこと
1. 講座のコードを参考に下記のコードを作成
```
 @Test
    public void 存在する本のIDを指定したときに正常に本のデータを返す() throws BookNotFoundException {
        doReturn(Optional.of(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル"))).when(bookMapper).findByBookId(1);

        Book actual = bookService.findBook(1);
        assertThat(actual).isEqualTo(new Book(1, "ノーゲーム・ノーライフ・1", "2012/04/30", true, 2, "ライトノベル"));
    }
 ``` 

2. intelliJ内でテストの実行->失敗し、下記のログが出る
<details><summary>エラーログ</summary><div>

> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava
> Task :processTestResources NO-SOURCE
> Task :testClasses
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
> Task :test FAILED


expected: com.ookawara.book.application.entity.Book@540dbda9
 but was: com.ookawara.book.application.entity.Book@377008df
org.opentest4j.AssertionFailedError: 
expected: com.ookawara.book.application.entity.Book@540dbda9
 but was: com.ookawara.book.application.entity.Book@377008df
	at java.base@17.0.7/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base@17.0.7/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base@17.0.7/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base@17.0.7/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at app//com.ookawara.book.application.service.BookServiceTest.存在する本のIDを指定したときに正常に本のデータを返す(BookServiceTest.java:96)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base@17.0.7/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.7/java.lang.reflect.Method.invoke(Method.java:568)
	at app//org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
	at app//org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at app//org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at app//org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at app//org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at app//org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at app//org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139)
	at app//org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base@17.0.7/java.util.ArrayList.forEach(ArrayList.java:1511)
	at app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base@17.0.7/java.util.ArrayList.forEach(ArrayList.java:1511)
	at app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at app//org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at app//org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at app//org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at app//org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at app//org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at app//org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at app//org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at app//org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at app//org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at app//org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base@17.0.7/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.7/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)


BookServiceTest > 存在する本のIDを指定したときに正常に本のデータを返す() FAILED
    org.opentest4j.AssertionFailedError at BookServiceTest.java:96
1 test completed, 1 failed
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':test'.
> There were failing tests. See the report at: file:///Users/ookawaramasato/%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%A0/%E6%9C%80%E7%B5%82%E8%AA%B2%E9%A1%8C/book-application/build/reports/tests/test/index.html
* Try:
> Run with --scan to get full insights.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
BUILD FAILED in 1s
4 actionable tasks: 2 executed, 2 up-to-date

</div></details>

3. ログを確認してデバッカーを使って値の確認
```
expected: com.ookawara.book.application.entity.Book@540dbda9
 but was: com.ookawara.book.application.entity.Book@377008df
```
から期待値と実際の値が合っていないと思ったのでデバッカーでBookServiceのfindByIdに入る値を確認したが全く同じ値が入っているように思い、何が原因で値が一致しないのかがわからない。

## 知りたいこと
どこを直したらテストが成功するのかを教えていただきたいです。