### PR TITLE
BookMapperのfindAllのDBテストを実装

### DIFF
--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -1,0 +1,47 @@
+package com.ookawara.book.application.mapper;
+
+import com.ookawara.book.application.entity.Book;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookMapperTest {
+
+    @Autowired
+    BookMapper bookMapper;
+
+    @Test
+    @Sql(
+            scripts = {"classpath:/sqlannotation/delete-categories.sql", "classpath:/sqlannotation/insert-categories.sql",
+                    "classpath:/sqlannotation/delete-books.sql", "classpath:/sqlannotation/insert-books.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void 全ての本のデータを返す() {
+        List<Book> books = bookMapper.findAll();
+        assertThat(books)
+                .hasSize(3)
+                .containsOnly(
+                        new Book(1, "ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2, "ライトノベル"),
+                        new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"),
+                        new Book(3, "ビブリア古書堂の事件手帖・1", LocalDate.of(2011, 3, 25), true, 3, "小説"));
+    }
+
+    @Test
+    @Sql(scripts = {"classpath:/sqlannotation/delete-categories.sql", "classpath:/sqlannotation/delete-books.sql"})
+    @Transactional
+    void レコードがないとき空のデータを返す() {
+        List<Book> books = bookMapper.findAll();
+        assertThat(books).isEmpty();
+    }
+}

--- a/src/test/resources/sqlannotation/delete-books.sql
+++ b/src/test/resources/sqlannotation/delete-books.sql
@@ -1,0 +1,2 @@
+DELETE FROM books;
+

--- a/src/test/resources/sqlannotation/delete-categories.sql
+++ b/src/test/resources/sqlannotation/delete-categories.sql
@@ -1,0 +1,1 @@
+DELETE FROM categories;

--- a/src/test/resources/sqlannotation/insert-books.sql
+++ b/src/test/resources/sqlannotation/insert-books.sql
@@ -1,0 +1,3 @@
+INSERT INTO books (book_id, name, reLease_date, is_purchased, category_id) VALUES (1, "ノーゲーム・ノーライフ・1", "2012/04/30", 1, 2);
+INSERT INTO books (book_id, name, reLease_date, is_purchased, category_id) VALUES (2, "鬼滅の刃・1", "2016/06/08", 0, 1);
+INSERT INTO books (book_id, name, reLease_date, is_purchased, category_id) VALUES (3, "ビブリア古書堂の事件手帖・1","2011/03/25",1,3);

--- a/src/test/resources/sqlannotation/insert-categories.sql
+++ b/src/test/resources/sqlannotation/insert-categories.sql
@@ -1,0 +1,3 @@
+INSERT INTO categories (category_id, category) VALUES (1, "漫画");
+INSERT INTO categories (category_id, category) VALUES (2, "ライトノベル");
+INSERT INTO categories (category_id, category) VALUES (3, "小説");


### PR DESCRIPTION
# 概要
- BookMapper の findAll のDBテストを実装しました。
- それに伴い、testのresourcesにbooksとcategoriesのdelete, insert .ymlファイルを作成。