### PR TITLE
findByCategoryIdのDBテストを実装/ServiceTest内のテスト内容を変更

### DIFF
--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -3,6 +3,7 @@ package com.ookawara.book.application.mapper;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.ookawara.book.application.entity.Book;
+import com.ookawara.book.application.entity.Category;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -149,5 +150,22 @@ class BookMapperTest {
     void 存在しない本のIDを指定した時に空のデータを返す() {
         Optional<Book> book = bookMapper.findByBookId(0);
         assertThat(book).isEmpty();
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void 存在するカテゴリーのIDを指定したときに正常にカテゴリーのデータを返す () {
+        Optional<Category> category = bookMapper.findByCategoryId(1);
+        assertThat(category)
+                .contains(new Category(1, "漫画"));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void 存在しないカテゴリーのIDを指定した時に空のデータを返す() {
+        Optional<Category> category = bookMapper.findByCategoryId(0);
+        assertThat(category).isEmpty();
     }
 }

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -118,9 +118,9 @@ class BookServiceTest {
 
     @Test
     public void 存在するカテゴリーのIDを指定したときに正常にカテゴリーのデータを返す() throws BookNotFoundException {
-        doReturn(Optional.of(new Category(1, "ライトノベル"))).when(bookMapper).findByCategoryId(1);
+        doReturn(Optional.of(new Category(1, "漫画"))).when(bookMapper).findByCategoryId(1);
         Category actual = bookService.findCategory(1);
-        assertThat(actual).isEqualTo(new Category(1, "ライトノベル"));
+        assertThat(actual).isEqualTo(new Category(1, "漫画"));
         verify(bookMapper).findByCategoryId(1);
     }
 


### PR DESCRIPTION
# 概要
- findByCategoryIdのDBテストをDBRiderで実装しました。
- BookServiceTest内の「存在するカテゴリーのIDを指定したときに正常にカテゴリーのデータを返す」テストで使っているデータが想定している値で実施していなかったので想定していたものに変更しました。