### PR TITLE
BookMapperにカテゴリーに対するinsert文とselect文を追加

### DIFF
--- a/src/main/java/com/ookawara/book/application/entity/Category.java
+++ b/src/main/java/com/ookawara/book/application/entity/Category.java
@@ -1,17 +1,25 @@
 package com.ookawara.book.application.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.util.Objects;
 
 public class Category {
-    private int categoryId;
+    private Integer categoryId;
     private String category;
 
-    public Category(int categoryId, String category) {
+    public Category(Integer categoryId, String category) {
         this.categoryId = categoryId;
         this.category = category;
     }
 
-    public int getCategoryId() {
+    public Category(String category) {
+//        categoryId は INSERT ⽂発⾏時に MySQL によって⾃動採番した値が補完されるので null を設定
+        this.categoryId = null;
+        this.category = category;
+    }
+
+    public Integer getCategoryId() {
         return categoryId;
     }
 

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -54,9 +54,16 @@ public interface BookMapper {
     Optional<Category> findByCategoryId(int categoryId);
 
     @Select("select * from books where name like #{name} and category_id like #{categoryId}")
-    Optional<Book> findByNameAndCategory(String name, int categoryId);
+    Optional<Book> findByNameAndCategoryId(String name, int categoryId);
+
+    @Select("select * from categories where category like #{category}")
+    Optional<Category> findByCategory(String category);
 
     @Insert("insert into books (name, release_date, is_purchased, category_id) values (#{name}, #{releaseDate}, #{isPurchased}, #{categoryId})")
     @Options(useGeneratedKeys = true, keyProperty = "bookId")
     void insertBook(Book book);
+
+    @Insert("insert into categories (category) values (#{category})")
+    @Options(useGeneratedKeys = true, keyProperty = "categoryId")
+    void insertCategory(Category category);
 }

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -54,7 +54,7 @@ public interface BookMapper {
     Optional<Category> findByCategoryId(int categoryId);
 
     @Select("select * from books where name like #{name} and category_id like #{categoryId}")
-    Optional<Book> findByNameAndCategoryId(String name, int categoryId);
+    Optional<Book> findByNameAndCategory(String name, int categoryId);
 
     @Select("select * from categories where category like #{category}")
     Optional<Category> findByCategory(String category);

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -1,6 +1,7 @@
 package com.ookawara.book.application.mapper;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.ookawara.book.application.entity.Book;
 import com.ookawara.book.application.entity.Category;
@@ -172,7 +173,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 書籍名に指定した文字列とカテゴリーIDに指定したIDが完全一致したデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategory("鬼滅の刃・1", 1);
+        Optional<Book> book = bookMapper.findByNameAndCategoryId("鬼滅の刃・1", 1);
         assertThat(book).contains(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1));
     }
 
@@ -180,8 +181,24 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 書籍名に指定した文字列とカテゴリーIDに指定したIDが一致しないとき空のデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategory(null, 0);
+        Optional<Book> book = bookMapper.findByNameAndCategoryId(null, 0);
         assertThat(book).isEmpty();
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void カテゴリーに指定した文字列が完全一致したデータを返す() {
+        Optional<Category> category = bookMapper.findByCategory("小説");
+        assertThat(category).contains(new Category(3,"小説"));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void カテゴリーに指定した文字列が一致しないとき空のデータを返す() {
+        Optional<Category> category = bookMapper.findByCategory("しょうせつ");
+        assertThat(category).isEmpty();
     }
 
     @Test
@@ -199,5 +216,14 @@ class BookMapperTest {
                 .hasSize(1)
                 .containsOnly(
                         new Book(1, "鬼滅の刃・2", LocalDate.of(2016, 8, 9), false, 1, "漫画"));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @ExpectedDataSet(value = "datasets/create-categories.yml", ignoreCols = "category_id")
+    @Transactional
+    void カテゴリーと新しく採番されたIDが正常に登録されること() {
+        Category category = new Category("エッセイ");
+        bookMapper.insertCategory(category);
     }
 }

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -173,7 +173,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 書籍名に指定した文字列とカテゴリーIDに指定したIDが完全一致したデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategoryId("鬼滅の刃・1", 1);
+        Optional<Book> book = bookMapper.findByNameAndCategory("鬼滅の刃・1", 1);
         assertThat(book).contains(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1));
     }
 
@@ -181,7 +181,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 書籍名に指定した文字列とカテゴリーIDに指定したIDが一致しないとき空のデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategoryId(null, 0);
+        Optional<Book> book = bookMapper.findByNameAndCategory(null, 0);
         assertThat(book).isEmpty();
     }
 

--- a/src/test/resources/datasets/create-categories.yml
+++ b/src/test/resources/datasets/create-categories.yml
@@ -1,0 +1,9 @@
+categories:
+  - category_id: 1
+    category: "漫画"
+  - category_id: 2
+    category: "ライトノベル"
+  - category_id: 3
+    category: "小説"
+  - category_id: 4
+    category: "エッセイ"


### PR DESCRIPTION
# 概要
・カテゴリーに対する登録処理を実装しています。
・BookMapperにカテゴリーの登録処理を実装しました。
・登録処理の実装に必要なselect文も同時に追加しています。
・それらに対するDBテストも追加しました。