### PR TITLE
カテゴリーに対する登録処理の追加

### DIFF
--- a/src/main/java/com/ookawara/book/application/entity/Book.java
+++ b/src/main/java/com/ookawara/book/application/entity/Book.java
@@ -24,8 +24,6 @@ public class Book {
     }
 
     public Book(String name, LocalDate releaseDate, Boolean isPurchased, Integer categoryId) {
-        // bookId は INSERT ⽂発⾏時に MySQL によって⾃動採番した値が補完されるので null を設定
-        this.bookId = null;
         this.name = name;
         this.releaseDate = releaseDate;
         this.isPurchased = isPurchased;

--- a/src/main/java/com/ookawara/book/application/entity/Category.java
+++ b/src/main/java/com/ookawara/book/application/entity/Category.java
@@ -1,17 +1,25 @@
 package com.ookawara.book.application.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 import java.util.Objects;
 
 public class Category {
-    private int categoryId;
+    private Integer categoryId;
     private String category;
 
-    public Category(int categoryId, String category) {
+    public Category(Integer categoryId, String category) {
         this.categoryId = categoryId;
         this.category = category;
     }
 
-    public int getCategoryId() {
+    public Category(String category) {
+//        categoryId は INSERT ⽂発⾏時に MySQL によって⾃動採番した値が補完されるので null を設定
+        this.categoryId = null;
+        this.category = category;
+    }
+
+    public Integer getCategoryId() {
         return categoryId;
     }
 

--- a/src/main/java/com/ookawara/book/application/entity/Category.java
+++ b/src/main/java/com/ookawara/book/application/entity/Category.java
@@ -14,8 +14,6 @@ public class Category {
     }
 
     public Category(String category) {
-//        categoryId は INSERT ⽂発⾏時に MySQL によって⾃動採番した値が補完されるので null を設定
-        this.categoryId = null;
         this.category = category;
     }
 

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -56,7 +56,14 @@ public interface BookMapper {
     @Select("select * from books where name like #{name} and category_id like #{categoryId}")
     Optional<Book> findByNameAndCategory(String name, int categoryId);
 
+    @Select("select * from categories where category like #{category}")
+    Optional<Category> findByCategory(String category);
+
     @Insert("insert into books (name, release_date, is_purchased, category_id) values (#{name}, #{releaseDate}, #{isPurchased}, #{categoryId})")
     @Options(useGeneratedKeys = true, keyProperty = "bookId")
     void insertBook(Book book);
+
+    @Insert("insert into categories (category) values (#{category})")
+    @Options(useGeneratedKeys = true, keyProperty = "categoryId")
+    void insertCategory(Category category);
 }

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -1,6 +1,7 @@
 package com.ookawara.book.application.mapper;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.ookawara.book.application.entity.Book;
 import com.ookawara.book.application.entity.Category;
@@ -185,6 +186,22 @@ class BookMapperTest {
     }
 
     @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void カテゴリーに指定した文字列が完全一致したデータを返す() {
+        Optional<Category> category = bookMapper.findByCategory("小説");
+        assertThat(category).contains(new Category(3,"小説"));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void カテゴリーに指定した文字列が一致しないとき空のデータを返す() {
+        Optional<Category> category = bookMapper.findByCategory("しょうせつ");
+        assertThat(category).isEmpty();
+    }
+
+    @Test
     @Sql(
             scripts = {"classpath:/sqlannotation/delete-books.sql", "classpath:/sqlannotation/reset-book-id.sql"},
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
@@ -199,5 +216,14 @@ class BookMapperTest {
                 .hasSize(1)
                 .containsOnly(
                         new Book(1, "鬼滅の刃・2", LocalDate.of(2016, 8, 9), false, 1, "漫画"));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @ExpectedDataSet(value = "datasets/create-categories.yml", ignoreCols = "category_id")
+    @Transactional
+    void カテゴリーと新しく採番されたIDが正常に登録されること() {
+        Category category = new Category("エッセイ");
+        bookMapper.insertCategory(category);
     }
 }

--- a/src/test/resources/datasets/create-categories.yml
+++ b/src/test/resources/datasets/create-categories.yml
@@ -1,0 +1,9 @@
+categories:
+  - category_id: 1
+    category: "漫画"
+  - category_id: 2
+    category: "ライトノベル"
+  - category_id: 3
+    category: "小説"
+  - category_id: 4
+    category: "エッセイ"


### PR DESCRIPTION
# 概要
・カテゴリーテーブルに対する登録処理を実装しています。
・Mapperに登録処理を追加しました。
・登録処理の実装に必要なselect文も同時に追加しました。
・それらに対するDBテストも追加しています。