### PR TITLE
メソッドfindByNameAndCategoryIdの名前の変更

### DIFF
--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -54,7 +54,7 @@ public interface BookMapper {
     Optional<Category> findByCategoryId(int categoryId);
 
     @Select("select * from books where name like #{name} and category_id like #{categoryId}")
-    Optional<Book> findByNameAndCategory(String name, int categoryId);
+    Optional<Book> findByNameAndCategoryId(String name, int categoryId);
 
     @Select("select * from categories where category like #{category}")
     Optional<Category> findByCategory(String category);

--- a/src/main/java/com/ookawara/book/application/service/BookService.java
+++ b/src/main/java/com/ookawara/book/application/service/BookService.java
@@ -47,7 +47,7 @@ public class BookService {
 
     public Book createBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId) {
         Book book = new Book(name, releaseDate, isPurchased, categoryId);
-        if (bookMapper.findByNameAndCategory(book.getName(), book.getCategoryId()).isPresent()) {
+        if (bookMapper.findByNameAndCategoryId(book.getName(), book.getCategoryId()).isPresent()) {
             throw new BookConflictException("すでに登録されています。");
         } else {
             bookMapper.insertBook(book);

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -173,7 +173,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 書籍名に指定した文字列とカテゴリーIDに指定したIDが完全一致したデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategory("鬼滅の刃・1", 1);
+        Optional<Book> book = bookMapper.findByNameAndCategoryId("鬼滅の刃・1", 1);
         assertThat(book).contains(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1));
     }
 
@@ -181,7 +181,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 書籍名に指定した文字列とカテゴリーIDに指定したIDが一致しないとき空のデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategory(null, 0);
+        Optional<Book> book = bookMapper.findByNameAndCategoryId(null, 0);
         assertThat(book).isEmpty();
     }
 

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -147,10 +147,10 @@ class BookServiceTest {
     @Test
     public void すでに存在する書籍データを登録しようとしたときに例外のエラーメッセージを返すこと() {
         doReturn(Optional.of(new Book("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2)))
-                .when(bookMapper).findByNameAndCategory("ノーゲーム・ノーライフ・1", 2);
+                .when(bookMapper).findByNameAndCategoryId("ノーゲーム・ノーライフ・1", 2);
         assertThatThrownBy(() -> bookService.createBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2))
                 .isInstanceOf(BookConflictException.class)
                 .hasMessage("すでに登録されています。");
-        verify(bookMapper).findByNameAndCategory("ノーゲーム・ノーライフ・1", 2);
+        verify(bookMapper).findByNameAndCategoryId("ノーゲーム・ノーライフ・1", 2);
     }
 }


### PR DESCRIPTION
# 概要
・メソッドのfindByNameAndCategoryIdの名前が間違っていたので修正しました。