### PR TITLE
Mapperに登録処理を追加

### DIFF
--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -8,9 +8,7 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
-import org.apache.ibatis.annotations.Update;
-import org.apache.ibatis.builder.annotation.ProviderMethodResolver;
-import org.apache.ibatis.jdbc.SQL;
+import org.apache.ibatis.annotations.UpdateProvider;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,29 +22,6 @@ public interface BookMapper {
     List<Book> findBy(@Param("category") String category,
                       @Param("name") String name,
                       @Param("isPurchased") Boolean isPurchased);
-
-    class BookSqlProvider implements ProviderMethodResolver {
-        public String findBy(@Param("category") String category,
-                             @Param("name") String name,
-                             @Param("isPurchased") Boolean isPurchased) {
-            return new SQL() {
-                {
-                    SELECT("*");
-                    FROM("books");
-                    JOIN("categories on books.category_id = categories.category_id");
-                    if (category != null) {
-                        WHERE("category like concat('%',#{category},'%')");
-                    }
-                    if (name != null) {
-                        WHERE("name like concat('%',#{name},'%')");
-                    }
-                    if (isPurchased != null) {
-                        WHERE("is_purchased = #{isPurchased}");
-                    }
-                }
-            }.toString();
-        }
-    }
 
     @Select("select * from books join categories on books.category_id = categories.category_id where book_id = #{bookId}")
     Optional<Book> findByBookId(int bookId);
@@ -68,6 +43,6 @@ public interface BookMapper {
     @Options(useGeneratedKeys = true, keyProperty = "categoryId")
     void insertCategory(Category category);
 
-    @Update("update books set name = #{name}, release_date = #{releaseDate}, is_purchased = #{isPurchased}, category_id = #{categoryId} where book_id = #{bookId}")
+    @UpdateProvider(BookSqlProvider.class)
     void updateBook(Book book);
 }

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -8,6 +8,7 @@ import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.Update;
 import org.apache.ibatis.builder.annotation.ProviderMethodResolver;
 import org.apache.ibatis.jdbc.SQL;
 
@@ -19,12 +20,12 @@ public interface BookMapper {
     @Select("select * from books join categories on books.category_id = categories.category_id")
     List<Book> findAll();
 
-    @SelectProvider(SqlProvider.class)
+    @SelectProvider(BookSqlProvider.class)
     List<Book> findBy(@Param("category") String category,
                       @Param("name") String name,
                       @Param("isPurchased") Boolean isPurchased);
 
-    class SqlProvider implements ProviderMethodResolver {
+    class BookSqlProvider implements ProviderMethodResolver {
         public String findBy(@Param("category") String category,
                              @Param("name") String name,
                              @Param("isPurchased") Boolean isPurchased) {
@@ -66,4 +67,7 @@ public interface BookMapper {
     @Insert("insert into categories (category) values (#{category})")
     @Options(useGeneratedKeys = true, keyProperty = "categoryId")
     void insertCategory(Category category);
+
+    @Update("update books set name = #{name}, release_date = #{releaseDate}, is_purchased = #{isPurchased}, category_id = #{categoryId} where book_id = #{bookId}")
+    void updateBook(Book book);
 }

--- a/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
@@ -1,0 +1,51 @@
+package com.ookawara.book.application.mapper;
+
+import com.ookawara.book.application.entity.Book;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.builder.annotation.ProviderMethodResolver;
+import org.apache.ibatis.jdbc.SQL;
+
+public class BookSqlProvider implements ProviderMethodResolver {
+    public String findBy(@Param("category") String category,
+                         @Param("name") String name,
+                         @Param("isPurchased") Boolean isPurchased) {
+        return new SQL() {
+            {
+                SELECT("*");
+                FROM("books");
+                JOIN("categories on books.category_id = categories.category_id");
+                if (category != null) {
+                    WHERE("category like concat('%',#{category},'%')");
+                }
+                if (name != null) {
+                    WHERE("name like concat('%',#{name},'%')");
+                }
+                if (isPurchased != null) {
+                    WHERE("is_purchased = #{isPurchased}");
+                }
+            }
+        }.toString();
+    }
+
+    public String updateBook(Book book) {
+        return new SQL() {
+            {
+                UPDATE("books");
+                if (book.getName() != null) {
+                    SET("name = #{name}");
+                }
+                if (book.getReleaseDate() != null) {
+                    SET("release_date = #{releaseDate}");
+                }
+                if (book.getIsPurchased() != null) {
+                    SET("is_purchased = #{isPurchased}");
+                }
+                if (book.getCategoryId() != null) {
+                    SET("category_id = #{categoryId}");
+                }
+                WHERE("book_id = #{bookId}");
+            }
+        }.toString();
+    }
+}
+

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -136,7 +136,7 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 存在する本のIDを指定したときに正常に本のデータを返す () {
+    void 存在する本のIDを指定したときに正常に本のデータを返す() {
         Optional<Book> book = bookMapper.findByBookId(1);
         assertThat(book)
                 .contains(
@@ -155,7 +155,7 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 存在するカテゴリーのIDを指定したときに正常にカテゴリーのデータを返す () {
+    void 存在するカテゴリーのIDを指定したときに正常にカテゴリーのデータを返す() {
         Optional<Category> category = bookMapper.findByCategoryId(1);
         assertThat(category)
                 .contains(new Category(1, "漫画"));
@@ -190,7 +190,7 @@ class BookMapperTest {
     @Transactional
     void カテゴリーに指定した文字列が完全一致したデータを返す() {
         Optional<Category> category = bookMapper.findByCategory("小説");
-        assertThat(category).contains(new Category(3,"小説"));
+        assertThat(category).contains(new Category(3, "小説"));
     }
 
     @Test
@@ -225,5 +225,14 @@ class BookMapperTest {
     void カテゴリーと新しく採番されたIDが正常に登録されること() {
         Category category = new Category("エッセイ");
         bookMapper.insertCategory(category);
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @ExpectedDataSet(value = "datasets/update-books.yml")
+    @Transactional
+    void IDで指定した書籍の購入履歴のみが更新できること() {
+        Book book = new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), true, 1);
+        bookMapper.updateBook(book);
     }
 }

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -232,7 +232,7 @@ class BookMapperTest {
     @ExpectedDataSet(value = "datasets/update-books.yml")
     @Transactional
     void IDで指定した書籍の購入履歴のみが更新できること() {
-        Book book = new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), true, 1);
+        Book book = new Book(2, null, null, true, null);
         bookMapper.updateBook(book);
     }
 }

--- a/src/test/resources/datasets/update-books.yml
+++ b/src/test/resources/datasets/update-books.yml
@@ -1,0 +1,16 @@
+books:
+  - book_id: 1
+    name: "ノーゲーム・ノーライフ・1"
+    release_date: "2012-04-30"
+    is_purchased: 1
+    category_id: 2
+  - book_id: 2
+    name: "鬼滅の刃・1"
+    release_date: "2016-06-08"
+    is_purchased: 1
+    category_id: 1
+  - book_id: 3
+    name: "ビブリア古書堂の事件手帖・1"
+    release_date: "2011-03-25"
+    is_purchased: 1
+    category_id: 3


### PR DESCRIPTION
# 概要
Mapperに記述する登録処理のSQL文について疑問が出たので質問します。
# 質問
## 質問内容
・@UpdateProviderを使った動的sql文で１つのカラムのみを更新できるようにする記述の仕方を知りたいです。
例としてIDを指定してデータを更新するときに下記のnameに入っているデータのみを更新するやり方を知りたいです。

テーブル情報
| books        | 
| :----------: | 
| book_id      | 
| name         | 
| release_date | 
| is_purchased | 
| category_id  | 
## 試したこと
``` Java
@Update("update books set name = #{name}, release_date = #{releaseDate}, is_purchased = #{isPurchased}, category_id = #{categoryId} where book_id = #{bookId}")
``` 
1, 上記sql文を@UpdateProviderを使って下記のようにカラム１つのみがsetで指定できるように書いてみる。
``` Java 
@UpdateProvider(BookSqlProvider.class)
    void updateBook(@Param("name") String name,
                    @Param("releaseDate") LocalDate releaseDate,
                    @Param("isPurchased") Boolean isPurchased,
                    @Param("categoryId") Integer categoryId);

public class BookSqlProvider implements ProviderMethodResolver {
    public String updateBook(@Param("name") String name,
                             @Param("releaseDate") LocalDate releaseDate,
                             @Param("isPurchased") Boolean isPurchased,
                             @Param("categoryId") Integer categoryId) {
        return new SQL() {
            {
                UPDATE("books");
                if (name != null) {
                    SET("name = #{name}");
                }
                if (releaseDate != null) {
                    SET("release_date = #{releaseDate}");
                }
                if (isPurchased != null) {
                    SET("is_purchased = #{isPurchased}");
                }
                if (categoryId != null) {
                    SET("category_id = #{categoryId}");
                }
                WHERE("book_id = #{bookId}");
            }
        }.toString();
    }
}
``` 

2, DBテストを下記のように実装してIDで指定したデータの内、一つのデータのみが更新できるようなテストを記述してみるが`bookMapper.updateBook(book)` この引数`book` で型が違うという注意がintelliJから発生する。
```Java 
@Test
    @DataSet("datasets/books.yml")
    @ExpectedDataSet(value = "datasets/update-books.yml")
    @Transactional
    void IDで指定した書籍の購入履歴のみが更新できること() {
        Book book = new Book(2, "", null, true, null);
        bookMapper.updateBook(book);
    }
``` 
3, `String` や`LocalDate` を`Book` に変えてみるが、今度は引数の数が違うという注意がintelliJから発生する。
4, 実装の仕方に躓いたため質問することにしました。
## 知りたいこと
・1 で書いた動的sqlの書き方は合っているのでしょうか？
・そもそも更新処理で１つのカラムのみを更新するときは動的sqlを使わないことが多いのでしょうか？
・動的sqlを使った実装をする場合、今回自分が書いたコードはどこがが原因なのでしょうか？

説明不足なところがあるかもしれませんが回答していただけると幸いです。