### PR TITLE
findByNameAndCategoryId -> findByBook に変更

### DIFF
--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -31,10 +31,10 @@ public interface BookMapper {
     Optional<Category> findByCategoryId(int categoryId);
 
     @Select("select * from books where name like #{name} and release_date like #{releaseDate} and is_purchased like #{isPurchased} and category_id like #{categoryId}")
-    Optional<Book> findByBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId);
+    Optional<Book> findBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId);
 
     @Select("select * from categories where category like #{category}")
-    Optional<Category> findByCategory(String category);
+    Optional<Category> findCategory(String category);
 
     @Insert("insert into books (name, release_date, is_purchased, category_id) values (#{name}, #{releaseDate}, #{isPurchased}, #{categoryId})")
     @Options(useGeneratedKeys = true, keyProperty = "bookId")

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -10,6 +10,7 @@ import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
 import org.apache.ibatis.annotations.UpdateProvider;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,8 +30,8 @@ public interface BookMapper {
     @Select("select * from categories where category_id = #{categoryId}")
     Optional<Category> findByCategoryId(int categoryId);
 
-    @Select("select * from books where name like #{name} and category_id like #{categoryId}")
-    Optional<Book> findByNameAndCategoryId(String name, int categoryId);
+    @Select("select * from books where name like #{name} and release_date like #{releaseDate} and is_purchased like #{isPurchased} and category_id like #{categoryId}")
+    Optional<Book> findByBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId);
 
     @Select("select * from categories where category like #{category}")
     Optional<Category> findByCategory(String category);

--- a/src/main/java/com/ookawara/book/application/service/BookService.java
+++ b/src/main/java/com/ookawara/book/application/service/BookService.java
@@ -48,7 +48,7 @@ public class BookService {
 
     public Book createBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId) {
         Book book = new Book(name, releaseDate, isPurchased, categoryId);
-        if (bookMapper.findByNameAndCategoryId(book.getName(), book.getCategoryId()).isPresent()) {
+        if (bookMapper.findByBook(book.getName(), book.getReleaseDate(), book.getIsPurchased(), book.getCategoryId()).isPresent()) {
             throw new BookDuplicateException("すでに登録されています。");
         } else {
             bookMapper.insertBook(book);

--- a/src/main/java/com/ookawara/book/application/service/BookService.java
+++ b/src/main/java/com/ookawara/book/application/service/BookService.java
@@ -48,7 +48,7 @@ public class BookService {
 
     public Book createBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId) {
         Book book = new Book(name, releaseDate, isPurchased, categoryId);
-        if (bookMapper.findByBook(book.getName(), book.getReleaseDate(), book.getIsPurchased(), book.getCategoryId()).isPresent()) {
+        if (bookMapper.findBook(book.getName(), book.getReleaseDate(), book.getIsPurchased(), book.getCategoryId()).isPresent()) {
             throw new BookDuplicateException("すでに登録されています。");
         } else {
             bookMapper.insertBook(book);
@@ -58,7 +58,7 @@ public class BookService {
 
     public Category createCategory(String category) {
         Category categoryName = new Category(category);
-        if (bookMapper.findByCategory(categoryName.getCategory()).isPresent()) {
+        if (bookMapper.findCategory(categoryName.getCategory()).isPresent()) {
             throw new CategoryDuplicateException("すでに登録されています。");
         } else {
             bookMapper.insertCategory(categoryName);

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -172,16 +172,16 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 書籍名に指定した文字列とカテゴリーIDに指定したIDが完全一致したデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategoryId("鬼滅の刃・1", 1);
+    void 指定した値が完全一致した本のデータを返す() {
+        Optional<Book> book = bookMapper.findByBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1);
         assertThat(book).contains(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1));
     }
 
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 書籍名に指定した文字列とカテゴリーIDに指定したIDが一致しないとき空のデータを返す() {
-        Optional<Book> book = bookMapper.findByNameAndCategoryId(null, 0);
+    void 指定した値がどれか一つでも一致しないとき空のデータを返す() {
+        Optional<Book> book = bookMapper.findByBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 0);
         assertThat(book).isEmpty();
     }
 

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -173,7 +173,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 指定した値が完全一致した本のデータを返す() {
-        Optional<Book> book = bookMapper.findByBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1);
+        Optional<Book> book = bookMapper.findBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1);
         assertThat(book).contains(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1));
     }
 
@@ -181,7 +181,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void 指定した値がどれか一つでも一致しないとき空のデータを返す() {
-        Optional<Book> book = bookMapper.findByBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 0);
+        Optional<Book> book = bookMapper.findBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 0);
         assertThat(book).isEmpty();
     }
 
@@ -189,7 +189,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void カテゴリーに指定した文字列が完全一致したデータを返す() {
-        Optional<Category> category = bookMapper.findByCategory("小説");
+        Optional<Category> category = bookMapper.findCategory("小説");
         assertThat(category).contains(new Category(3, "小説"));
     }
 
@@ -197,7 +197,7 @@ class BookMapperTest {
     @DataSet("datasets/books.yml")
     @Transactional
     void カテゴリーに指定した文字列が一致しないとき空のデータを返す() {
-        Optional<Category> category = bookMapper.findByCategory("しょうせつ");
+        Optional<Category> category = bookMapper.findCategory("しょうせつ");
         assertThat(category).isEmpty();
     }
 

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -148,11 +148,11 @@ class BookServiceTest {
     @Test
     public void すでに存在する書籍データを登録しようとしたときに例外のエラーメッセージを返すこと() {
         doReturn(Optional.of(new Book("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2)))
-                .when(bookMapper).findByBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
+                .when(bookMapper).findBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
         assertThatThrownBy(() -> bookService.createBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2))
                 .isInstanceOf(BookDuplicateException.class)
                 .hasMessage("すでに登録されています。");
-        verify(bookMapper).findByBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
+        verify(bookMapper).findBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
     }
 
     @Test
@@ -167,10 +167,10 @@ class BookServiceTest {
     @Test
     public void すでに存在するカテゴリーを登録しようとしたときに例外のエラーメッセージを返すこと() {
         doReturn(Optional.of(new Category("漫画")))
-                .when(bookMapper).findByCategory("漫画");
+                .when(bookMapper).findCategory("漫画");
         assertThatThrownBy(() -> bookService.createCategory("漫画"))
                 .isInstanceOf(CategoryDuplicateException.class)
                 .hasMessage("すでに登録されています。");
-        verify(bookMapper).findByCategory("漫画");
+        verify(bookMapper).findCategory("漫画");
     }
 }

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -148,11 +148,11 @@ class BookServiceTest {
     @Test
     public void すでに存在する書籍データを登録しようとしたときに例外のエラーメッセージを返すこと() {
         doReturn(Optional.of(new Book("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2)))
-                .when(bookMapper).findByNameAndCategoryId("ノーゲーム・ノーライフ・1", 2);
+                .when(bookMapper).findByBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
         assertThatThrownBy(() -> bookService.createBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2))
                 .isInstanceOf(BookDuplicateException.class)
                 .hasMessage("すでに登録されています。");
-        verify(bookMapper).findByNameAndCategoryId("ノーゲーム・ノーライフ・1", 2);
+        verify(bookMapper).findByBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
     }
 
     @Test


### PR DESCRIPTION
# 概要
・findByNameAndCategoryIdメソッドをfindByBookとしてID以外の全レコードが完全一致する本のデータを取得できるように変更しました。
・それに伴い、DBテスト等の該当箇所も修正しています。