### PR TITLE
BookServiceのupdateBookに対する単体テストを追加

### DIFF
--- a/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
@@ -31,7 +31,7 @@ public class BookSqlProvider implements ProviderMethodResolver {
         return new SQL() {
             {
                 UPDATE("books");
-                if (book.getName() != null) {
+                if (!book.getName().isBlank()) {
                     SET("name = #{name}");
                 }
                 if (book.getReleaseDate() != null) {
@@ -40,7 +40,7 @@ public class BookSqlProvider implements ProviderMethodResolver {
                 if (book.getIsPurchased() != null) {
                     SET("is_purchased = #{isPurchased}");
                 }
-                if (book.getCategoryId() != null) {
+                if (book.getCategoryId() >= 1) {
                     SET("category_id = #{categoryId}");
                 }
                 WHERE("book_id = #{bookId}");

--- a/src/main/java/com/ookawara/book/application/service/BookService.java
+++ b/src/main/java/com/ookawara/book/application/service/BookService.java
@@ -67,7 +67,7 @@ public class BookService {
         }
     }
 
-    public Book updateBook(int bookId, String name, LocalDate releaseDate, Boolean isPurchased, int categoryId) {
+    public Book updateBook(int bookId, String name, LocalDate releaseDate, Boolean isPurchased, Integer categoryId) {
         bookMapper.findByBookId(bookId).orElseThrow(
                 () -> new BookNotFoundException("book：" + bookId + " のデータはありません。"));
         Book book = new Book(name, releaseDate, isPurchased, categoryId);

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -241,7 +241,7 @@ class BookMapperTest {
     @ExpectedDataSet(value = "datasets/update/update-books-name.yml")
     @Transactional
     void IDで指定した書籍の名前のみが更新できること() {
-        Book book = new Book(2, "鬼滅の刃 1", null, false, null);
+        Book book = new Book(2, "鬼滅の刃 1", null, false, 0);
         bookMapper.updateBook(book);
     }
 
@@ -250,7 +250,7 @@ class BookMapperTest {
     @ExpectedDataSet(value = "datasets/update/update-books-releaseDate.yml")
     @Transactional
     void IDで指定した書籍の発売日のみが更新できること() {
-        Book book = new Book(2, null, LocalDate.of(2016, 7, 8), false, null);
+        Book book = new Book(2, "", LocalDate.of(2016, 7, 8), false, 0);
         bookMapper.updateBook(book);
     }
 
@@ -259,7 +259,7 @@ class BookMapperTest {
     @ExpectedDataSet(value = "datasets/update/update-books-isPurchased.yml")
     @Transactional
     void IDで指定した書籍の購入履歴のみが更新できること() {
-        Book book = new Book(2, null, null, true, null);
+        Book book = new Book(2, "", null, true, 0);
         bookMapper.updateBook(book);
     }
 
@@ -268,7 +268,7 @@ class BookMapperTest {
     @ExpectedDataSet(value = "datasets/update/update-books-categoryId.yml")
     @Transactional
     void IDで指定した書籍のカテゴリーIDのみが更新できること() {
-        Book book = new Book(2, null, null, false, 2);
+        Book book = new Book(2, "", null, false, 2);
         bookMapper.updateBook(book);
     }
 }

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -188,6 +188,54 @@ class BookServiceTest {
     }
 
     @Test
+    public void 存在する本のIDを指定して書籍名だけを正常に更新できること() {
+        doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
+                .when(bookMapper).findByBookId(2);
+        Book book = new Book("鬼滅の刃 1", null, false, 0);
+        doNothing().when(bookMapper).updateBook(book);
+        Book actual = bookService.updateBook(2, "鬼滅の刃 1", null, false, 0);
+        assertThat(actual).isEqualTo(book);
+        verify(bookMapper).findByBookId(2);
+        verify(bookMapper).updateBook(book);
+    }
+
+    @Test
+    public void 存在する本のIDを指定して発売日だけを正常に更新できること() {
+        doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
+                .when(bookMapper).findByBookId(2);
+        Book book = new Book("", LocalDate.of(2016, 7, 8), false, 0);
+        doNothing().when(bookMapper).updateBook(book);
+        Book actual = bookService.updateBook(2, "", LocalDate.of(2016, 7, 8), false, 0);
+        assertThat(actual).isEqualTo(book);
+        verify(bookMapper).findByBookId(2);
+        verify(bookMapper).updateBook(book);
+    }
+
+    @Test
+    public void 存在する本のIDを指定して購入履歴だけを正常に更新できること() {
+        doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
+                .when(bookMapper).findByBookId(2);
+        Book book = new Book("", null, true, 0);
+        doNothing().when(bookMapper).updateBook(book);
+        Book actual = bookService.updateBook(2, "", null, true, 0);
+        assertThat(actual).isEqualTo(book);
+        verify(bookMapper).findByBookId(2);
+        verify(bookMapper).updateBook(book);
+    }
+
+    @Test
+    public void 存在する本のIDを指定してカテゴリーIDだけを正常に更新できること() {
+        doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
+                .when(bookMapper).findByBookId(2);
+        Book book = new Book("", null, false, 2);
+        doNothing().when(bookMapper).updateBook(book);
+        Book actual = bookService.updateBook(2, "", null, false, 2);
+        assertThat(actual).isEqualTo(book);
+        verify(bookMapper).findByBookId(2);
+        verify(bookMapper).updateBook(book);
+    }
+
+    @Test
     public void 存在する本のIDを指定して更新するレコード全てが元のデータと同じときに例外のメッセージを返すこと() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -179,7 +179,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定して全てのレコードを正常に更新できること() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        Book book = new Book("鬼滅の刃 1", LocalDate.of(2016, 7, 8), true, 2);
+        Book book = new Book(2, "鬼滅の刃 1", LocalDate.of(2016, 7, 8), true, 2);
         doNothing().when(bookMapper).updateBook(book);
         Book actual = bookService.updateBook(2, "鬼滅の刃 1", LocalDate.of(2016, 7, 8), true, 2);
         assertThat(actual).isEqualTo(book);
@@ -191,7 +191,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定して書籍名だけを正常に更新できること() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        Book book = new Book("鬼滅の刃 1", null, false, 0);
+        Book book = new Book(2, "鬼滅の刃 1", null, false, 0);
         doNothing().when(bookMapper).updateBook(book);
         Book actual = bookService.updateBook(2, "鬼滅の刃 1", null, false, 0);
         assertThat(actual).isEqualTo(book);
@@ -203,7 +203,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定して発売日だけを正常に更新できること() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        Book book = new Book("", LocalDate.of(2016, 7, 8), false, 0);
+        Book book = new Book(2, "", LocalDate.of(2016, 7, 8), false, 0);
         doNothing().when(bookMapper).updateBook(book);
         Book actual = bookService.updateBook(2, "", LocalDate.of(2016, 7, 8), false, 0);
         assertThat(actual).isEqualTo(book);
@@ -215,7 +215,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定して購入履歴だけを正常に更新できること() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        Book book = new Book("", null, true, 0);
+        Book book = new Book(2, "", null, true, 0);
         doNothing().when(bookMapper).updateBook(book);
         Book actual = bookService.updateBook(2, "", null, true, 0);
         assertThat(actual).isEqualTo(book);
@@ -227,7 +227,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定してカテゴリーIDだけを正常に更新できること() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        Book book = new Book("", null, false, 2);
+        Book book = new Book(2, "", null, false, 2);
         doNothing().when(bookMapper).updateBook(book);
         Book actual = bookService.updateBook(2, "", null, false, 2);
         assertThat(actual).isEqualTo(book);
@@ -239,7 +239,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定して更新するレコード全てが元のデータと同じときに例外のメッセージを返すこと() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        doReturn(Optional.of(new Book("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
+        doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1);
         assertThatThrownBy(() -> bookService.updateBook(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1))
                 .isInstanceOf(BookNotUpdatedException.class)

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -239,7 +239,7 @@ class BookServiceTest {
     public void 存在する本のIDを指定して更新するレコード全てが元のデータと同じときに例外のメッセージを返すこと() {
         doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBookId(2);
-        doReturn(Optional.of(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
+        doReturn(Optional.of(new Book("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1)))
                 .when(bookMapper).findByBook("鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1);
         assertThatThrownBy(() -> bookService.updateBook(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1))
                 .isInstanceOf(BookNotUpdatedException.class)


### PR DESCRIPTION
# 注意！
# コンストラクタ（2が）の呼び出しがmainと変更変更被っている可能性あり

# 概要
・BookServiceのupdateBookに対する単体テストを追加しました。
・実装するにあたってBookSqlProviderのupdateBook内の判定方法を変更しました。
3da957971ac4df26552383213fa6e36c6c4db7ef

・上記理由によりDBテストの該当箇所も記述を修正しています。
43f3f45593bb0b1a8ff828840b32cd1fd2951bd4