### PR TITLE
BookServiceのcreateBookに例外処理を追加

### DIFF
--- a/src/main/java/com/ookawara/book/application/service/BookService.java
+++ b/src/main/java/com/ookawara/book/application/service/BookService.java
@@ -47,12 +47,16 @@ public class BookService {
     }
 
     public Book createBook(String name, LocalDate releaseDate, Boolean isPurchased, int categoryId) {
-        Book book = new Book(name, releaseDate, isPurchased, categoryId);
-        if (bookMapper.findBookBy(book.getName(), book.getReleaseDate(), book.getIsPurchased(), book.getCategoryId()).isPresent()) {
-            throw new BookDuplicateException("すでに登録されています。");
+        if (bookMapper.findByCategoryId(categoryId).isPresent()) {
+            Book book = new Book(name, releaseDate, isPurchased, categoryId);
+            if (bookMapper.findBookBy(book.getName(), book.getReleaseDate(), book.getIsPurchased(), book.getCategoryId()).isPresent()) {
+                throw new BookDuplicateException("すでに登録されています。");
+            } else {
+                bookMapper.insertBook(book);
+                return book;
+            }
         } else {
-            bookMapper.insertBook(book);
-            return book;
+            throw new CategoryNotFoundException("categoryId：" + categoryId + " のデータがありません。");
         }
     }
 

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -138,21 +138,34 @@ class BookServiceTest {
 
     @Test
     public void 本のデータを正常に登録できること() {
+        doReturn(Optional.of(new Category(1, "漫画"))).when(bookMapper).findByCategoryId(1);
         Book book = new Book("鬼滅の刃・2", LocalDate.of(2016, 8, 9), false, 1);
         doNothing().when(bookMapper).insertBook(book);
         Book actual = bookService.createBook("鬼滅の刃・2", LocalDate.of(2016, 8, 9), false, 1);
         assertThat(actual).isEqualTo(book);
+        verify(bookMapper).findByCategoryId(1);
         verify(bookMapper).insertBook(book);
     }
 
     @Test
     public void すでに存在する書籍データを登録しようとしたときに例外のエラーメッセージを返すこと() {
+        doReturn(Optional.of(new Category(2, "ライトノベル"))).when(bookMapper).findByCategoryId(2);
         doReturn(Optional.of(new Book("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2)))
                 .when(bookMapper).findBookBy("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
         assertThatThrownBy(() -> bookService.createBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2))
                 .isInstanceOf(BookDuplicateException.class)
                 .hasMessage("すでに登録されています。");
+        verify(bookMapper).findByCategoryId(2);
         verify(bookMapper).findBookBy("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2);
+    }
+
+    @Test
+    public void 登録する書籍データに存在しないカテゴリーIDを指定したときに例外のエラーメッセージを返すこと() {
+        doReturn(Optional.empty()).when(bookMapper).findByCategoryId(999999999);
+        assertThatThrownBy(() -> bookService.createBook("ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 999999999))
+                .isInstanceOf(CategoryNotFoundException.class)
+                .hasMessage("categoryId：" + 999999999 + " のデータがありません。");
+        verify(bookMapper).findByCategoryId(999999999);
     }
 
     @Test

--- a/src/test/java/integrationtest/BookRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/BookRestApiIntegrationTest.java
@@ -30,6 +30,8 @@ class BookRestApiIntegrationTest {
     @Autowired
     MockMvc mockMvc;
 
+//    GET
+
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
@@ -250,6 +252,8 @@ class BookRestApiIntegrationTest {
         )));
     }
 
+//    POST
+
     @Test
     @DataSet("datasets/books.yml")
     @ExpectedDataSet(value = "datasets/create/create-books.yml", ignoreCols = "book_id")
@@ -295,6 +299,34 @@ class BookRestApiIntegrationTest {
                     "status": "409",
                     "error": "Conflict",
                     "message": "すでに登録されています。",
+                    "path": "/books"
+                }
+                """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true
+        )));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void 登録する書籍データに存在しないカテゴリーIDを指定したときに例外のエラーメッセージを返すこと() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.post("/books")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "ノーゲーム・ノーライフ・1",
+                                    "releaseDate": "2012-04-30",
+                                    "isPurchased": true,
+                                    "categoryId": 100
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                {
+                    "timestamp": "2024-01-01 00:00:00.000000+09:00[Asia/Tokyo]",
+                    "status": "404",
+                    "error": "Not Found",
+                    "message": "categoryId：100 のデータがありません。",
                     "path": "/books"
                 }
                 """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true


### PR DESCRIPTION
# 概要
・登録処理でcategoryIdに指定したIDのカテゴリーがない時に例外をthrowする処理を追加しました。
・それに対するServiceの単体テストと結合テストも追加しました。