### PR TITLE
日付フォーマットチェックの実装

### DIFF
--- a/src/main/java/com/ookawara/book/application/controller/request/BookUpdateRequest.java
+++ b/src/main/java/com/ookawara/book/application/controller/request/BookUpdateRequest.java
@@ -1,22 +1,21 @@
 package com.ookawara.book.application.controller.request;
 
+import com.ookawara.book.application.util.DateTimeFormat;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
 
 public class BookUpdateRequest {
     private String name;
 
-    @PastOrPresent(message = "現在もしくは過去の日付を入力してください")
-    private LocalDate releaseDate;
+    private String releaseDate;
 
     private Boolean isPurchased;
 
     @Min(value = 1, message = "1 以上の値にしてください")
     private Integer categoryId;
 
-    public BookUpdateRequest(String name, LocalDate releaseDate, Boolean isPurchased, Integer categoryId) {
+    public BookUpdateRequest(String name, String releaseDate, Boolean isPurchased, Integer categoryId) {
         this.name = name;
         this.releaseDate = releaseDate;
         this.isPurchased = isPurchased;
@@ -28,7 +27,8 @@ public class BookUpdateRequest {
     }
 
     public LocalDate getReleaseDate() {
-        return releaseDate;
+        DateTimeFormat dateTimeFormat = new DateTimeFormat(releaseDate);
+        return dateTimeFormat.getFormat();
     }
 
     public Boolean getIsPurchased() {

--- a/src/main/java/com/ookawara/book/application/exception/DateFormatException.java
+++ b/src/main/java/com/ookawara/book/application/exception/DateFormatException.java
@@ -1,0 +1,7 @@
+package com.ookawara.book.application.exception;
+
+public class DateFormatException extends RuntimeException {
+    public DateFormatException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ookawara/book/application/exception/ExceptionHandlerController.java
+++ b/src/main/java/com/ookawara/book/application/exception/ExceptionHandlerController.java
@@ -87,4 +87,18 @@ public class ExceptionHandlerController {
 
         return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(DateFormatException.class)
+    public ResponseEntity<Map<String, String>> handleDateFormatException(
+            DateFormatException e, HttpServletRequest request) {
+
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/ookawara/book/application/util/DateTimeFormat.java
+++ b/src/main/java/com/ookawara/book/application/util/DateTimeFormat.java
@@ -1,0 +1,29 @@
+package com.ookawara.book.application.util;
+
+import com.ookawara.book.application.exception.DateFormatException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+
+public class DateTimeFormat {
+
+    private String format;
+
+    public DateTimeFormat(String format) {
+        this.format = format;
+    }
+
+    public LocalDate getFormat() {
+        if (format != null) {
+            try {
+                return LocalDate.parse(format, DateTimeFormatter.ofPattern("uuuu/MM/dd").withResolverStyle(ResolverStyle.STRICT));
+            } catch (DateTimeParseException e) {
+                throw new DateFormatException("yyyy/MM/dd の形式（例：2000/01/01）で存在する日付を入力してください。");
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/ookawara/book/application/validationtest/BookUpdateRequestTest.java
+++ b/src/test/java/com/ookawara/book/application/validationtest/BookUpdateRequestTest.java
@@ -8,7 +8,6 @@ import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,18 +23,8 @@ class BookUpdateRequestTest {
     }
 
     @Test
-    void 発売日が未来の年月日のときバリーデーションエラーが発生すること() {
-        BookUpdateRequest bookRequest = new BookUpdateRequest("鬼滅の刃・1", LocalDate.of(9999, 12, 31), false, 1);
-        Set<ConstraintViolation<BookUpdateRequest>> violations = validator.validate(bookRequest);
-        assertThat(violations).hasSize(1);
-        assertThat(violations)
-                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(tuple("releaseDate", "現在もしくは過去の日付を入力してください"));
-    }
-
-    @Test
     void カテゴリーIDが1より小さい数字のときバリーデーションエラーが発生すること() {
-        BookUpdateRequest bookRequest = new BookUpdateRequest("鬼滅の刃・1", LocalDate.now(), false, 0);
+        BookUpdateRequest bookRequest = new BookUpdateRequest("鬼滅の刃・1", "2000/01/01", false, 0);
         Set<ConstraintViolation<BookUpdateRequest>> violations = validator.validate(bookRequest);
         assertThat(violations).hasSize(1);
         assertThat(violations)
@@ -44,20 +33,8 @@ class BookUpdateRequestTest {
     }
 
     @Test
-    void 発売日とカテゴリーIDのバリデーションエラーが同時に発生すること() {
-        BookUpdateRequest bookRequest = new BookUpdateRequest("", LocalDate.of(9999, 12, 31), false, 0);
-        Set<ConstraintViolation<BookUpdateRequest>> violations = validator.validate(bookRequest);
-        assertThat(violations).hasSize(2);
-        assertThat(violations)
-                .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                .containsExactlyInAnyOrder(
-                        tuple("releaseDate", "現在もしくは過去の日付を入力してください"),
-                        tuple("categoryId", "1 以上の値にしてください"));
-    }
-
-    @Test
     void 全てのフィールドに正常値があるときバリデーションエラーとならないこと() {
-        BookUpdateRequest bookRequest = new BookUpdateRequest(null, LocalDate.now(), null, 1);
+        BookUpdateRequest bookRequest = new BookUpdateRequest(null, "2000/01/01", null, 1);
         Set<ConstraintViolation<BookUpdateRequest>> violations = validator.validate(bookRequest);
         assertThat(violations).isEmpty();
     }

--- a/src/test/java/integrationtest/BookRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/BookRestApiIntegrationTest.java
@@ -390,7 +390,7 @@ class BookRestApiIntegrationTest {
                         .content("""
                                 {
                                     "name": "鬼滅の刃 1",
-                                    "releaseDate": "2016-07-08",
+                                    "releaseDate": "2016/07/08",
                                     "isPurchased": true,
                                     "categoryId": 2
                                 }
@@ -432,7 +432,7 @@ class BookRestApiIntegrationTest {
                         .content("""
                                 {
                                     "name": "鬼滅の刃 1",
-                                    "releaseDate": "2016-07-08",
+                                    "releaseDate": "2016/07/08",
                                     "isPurchased": true,
                                     "categoryId": 1
                                 }
@@ -460,7 +460,7 @@ class BookRestApiIntegrationTest {
                         .content("""
                                 {
                                     "name": "鬼滅の刃 1",
-                                    "releaseDate": "2016-07-08",
+                                    "releaseDate": "2016/07/08",
                                     "isPurchased": true,
                                     "categoryId": 999999999
                                 }

--- a/src/test/java/integrationtest/BookRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/BookRestApiIntegrationTest.java
@@ -478,4 +478,29 @@ class BookRestApiIntegrationTest {
                 """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true
         )));
     }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void 更新する発売日にフォーマットが違う文字列を指定したとき例外が発生すること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/books/2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "releaseDate": "2024-02-29"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                {
+                    "timestamp": "2024-01-01 00:00:00.000000+09:00[Asia/Tokyo]",
+                    "status": "400",
+                    "error": "Bad Request",
+                    "message": "yyyy/MM/dd の形式（例：2000/01/01）で存在する日付を入力してください。",
+                    "path": "/books/2"
+                }
+                """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true
+        )));
+    }
 }


### PR DESCRIPTION
# 概要
・リクエスト時に日付を入力するときのフォーマットチェックがControllerに更新処理を追加する時に実装できておらず、PRで指摘をいただいたが、ファイルの変更数が多くなってしまうため日付フォーマットチェックのみ別でPRを作成しました。
・util ディレクトリ内に作成したDateTimeFormat というクラスで受け取ったString型の日付をLocalDate型に変更しています。その際指定したフォーマットになっていない場合、また存在しない日付だった場合例外をスローするように実装してみました。
・また、未来の日付を入力したときのバリデーションチェックについては「未来の日付も入力可能」と仕様を変更したため取り除いています。