### PR TITLE
GitHub Actions でカバレッジ結果をアップロードする

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,4 +47,4 @@ jobs:
         if: always()
         with:
           name: coverage-test-report
-          path: 最終課題/reports/tests/coverage
+          path: reports/coverage

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,4 +47,4 @@ jobs:
         if: always()
         with:
           name: coverage-test-report
-          path: src/test/java
+          path: build/reports/tests/test

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,11 +47,11 @@ jobs:
         if: always()
         with:
           name: test-coverage-report
-          path: build/reports/tests/test/index.html
+          path: build/reports/tests/test/
 
       - name: Download coverage reports
         uses: actions/download-artifact@v4
         if: always()
         with:
           name: test-coverage-report
-          path: ダウンロード/
+          path: download/coverageReport

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -2,9 +2,11 @@ name: Run Test with Gradle
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main" , "feature/**" , "revise/**" ]
+    paths: [ "src/**" , ".github/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main" , "feature/**" , "revise/**" ]
+    paths: [ "src/**" , ".github/**" ]
 
 jobs:
   build:
@@ -39,3 +41,10 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           job_name: 'Test Report'
+
+      - name: test with code coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-test-report
+          path: reports/tests/coverage

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,4 +47,4 @@ jobs:
         if: always()
         with:
           name: coverage-test-report
-          path: reports/coverage
+          path: src/test/java

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,4 +47,4 @@ jobs:
         if: always()
         with:
           name: coverage-test-report
-          path: reports/tests/coverage
+          path: 最終課題/reports/tests/coverage

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -47,11 +47,11 @@ jobs:
         if: always()
         with:
           name: test-coverage-report
-          path: build/reports/tests/test
+          path: build/reports/tests/test/index.html
 
       - name: Download coverage reports
         uses: actions/download-artifact@v4
         if: always()
         with:
           name: test-coverage-report
-          path: build/reports/tests/test
+          path: ダウンロード/

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -42,9 +42,16 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           job_name: 'Test Report'
 
-      - name: test with code coverage
+      - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: coverage-test-report
+          name: test-coverage-report
+          path: build/reports/tests/test
+
+      - name: Download coverage reports
+        uses: actions/download-artifact@v4
+        if: always()
+        with:
+          name: test-coverage-report
           path: build/reports/tests/test


### PR DESCRIPTION
# 概要
・READMEにカバレッジ結果を添付するためにGitHub Actions 実行時にカバレッジ結果がアップロードされるようにワークフローに実装してみました。
・main ブランチからcheckout したブランチに対してPRを作成したときにもGitHub Actions を動作させたかったためワークフロー実行の条件を修正しました。
・自動テスト、CI に関係のあるファイルの変更をしたときにGithub Actions が動作するようにさせたかったためワークフローを修正しました。