### PR TITLE
GitHub Actionsでzip化してダウンロードできるようにするところまで自動化

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -2,9 +2,11 @@ name: Run Test with Gradle
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main" , "feature/**" , "revise/**" ]
+    paths: [ "src/**" , ".github/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main" , "feature/**" , "revise/**" ]
+    paths: [ "src/**" , ".github/**" ]
 
 jobs:
   build:
@@ -39,3 +41,10 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           job_name: 'Test Report'
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-coverage-report
+          path: build/reports/tests/test/

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -2,12 +2,10 @@ name: Run Test with Gradle
 
 on:
   push:
-    branches: [ "main" , "feature/**" , "revise/**" ]
-    paths: [ "src/**" , ".github/**" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" , "feature/**" , "revise/**" ]
-    paths: [ "src/**" , ".github/**" ]
-
+    
 jobs:
   build:
 

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" , "feature/**" , "revise/**" ]
-    
+
 jobs:
   build:
 


### PR DESCRIPTION
# 概要
・GitHub Actionsでzip化してダウンロードできるようにするところまで自動化できるようにワークフローに処理を追加しました。
・main ブランチからcheckout したブランチに対してPRを作成したときにもGitHub Actions を動作させたかったためワークフロー実行の条件を修正しました。
・自動テスト、CI に関係のあるファイルの変更をしたときにGithub Actions が動作するようにさせたかったためワークフローを修正しました。