### PR TITLE
API仕様書にエラー時の記述を追加

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -463,7 +463,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Referenced'
+                $ref: '#/components/schemas/ReferencedCategory'
 components:
   schemas:
     BookBadRequest:
@@ -546,8 +546,8 @@ components:
         path:
           type: string
           example: 指定したパス
-    Referenced:
-      description: 指定したリソースが別のデータベースで参照されているときのレスポンス
+    ReferencedCategory:
+      description: 書籍情報に削除対象のカテゴリーが存在するときのレスポンス
       type: object
       properties:
         timestamp:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -458,6 +458,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotFound'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Referenced'
 components:
   schemas:
     BookBadRequest:
@@ -537,6 +543,25 @@ components:
         message:
           type: string
           example: すでに登録されています。
+        path:
+          type: string
+          example: 指定したパス
+    Referenced:
+      description: 指定したリソースが別のデータベースで参照されているときのレスポンス
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        status:
+          type: string
+          example: 422
+        error:
+          type: string
+          example: Unprocessable Entity
+        message:
+          type: string
+          example: 他のデータベースで参照されています。
         path:
           type: string
           example: 指定したパス

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -17,7 +17,7 @@ CREATE TABLE books (
  is_purchased TINYINT(1) NOT NULL DEFAULT 0,
  category_id int unsigned,
  PRIMARY KEY (book_id),
- CONSTRAINT fk_books_category_id FOREIGN KEY (category_id) REFERENCES categories (category_id) ON DELETE SET NULL ON UPDATE CASCADE
+ CONSTRAINT fk_books_category_id FOREIGN KEY (category_id) REFERENCES categories (category_id) ON DELETE NO ACTION ON UPDATE CASCADE
 );
 
 INSERT INTO books (name, reLease_date, is_purchased, category_id) VALUES ("ノーゲーム・ノーライフ・1", "2012/04/30", 1, 2);


### PR DESCRIPTION
# 概要
・READMEとAPI仕様書に則って機能等の追加・修正を行なっています。

・READMEのデータベースの定義でbooks テーブルのcategory_id にDELET NOT ACTIONS を設定したため、API仕様書のDELETE categories/{categoryId} にエラー時の記述を新たに追加しました。
