### PR TITLE
クエリパラメータで発売日を検索する機能の追加

### DIFF
--- a/src/main/java/com/ookawara/book/application/controller/BookController.java
+++ b/src/main/java/com/ookawara/book/application/controller/BookController.java
@@ -8,6 +8,7 @@ import com.ookawara.book.application.controller.response.CategoryResponse;
 import com.ookawara.book.application.entity.Book;
 import com.ookawara.book.application.entity.Category;
 import com.ookawara.book.application.service.BookService;
+import com.ookawara.book.application.util.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -33,10 +34,12 @@ public class BookController {
     }
 
     @GetMapping("/books")
-    public List<Book> getBooksAllData(@RequestParam(required = false, defaultValue = "") String category,
-                                      @RequestParam(required = false, defaultValue = "") String name,
-                                      @RequestParam(required = false, defaultValue = "") Boolean isPurchased) {
-        return bookService.findBy(category, name, isPurchased);
+    public List<Book> getBooksAllData(@RequestParam(required = false, defaultValue = "") String name,
+                                      @RequestParam(required = false, defaultValue = "") String releaseDate,
+                                      @RequestParam(required = false, defaultValue = "") Boolean isPurchased,
+                                      @RequestParam(required = false, defaultValue = "") String category) {
+        DateTimeFormat formattedReleaseDate = new DateTimeFormat(releaseDate);
+        return bookService.findBy(name, formattedReleaseDate.getFormatCheck(), isPurchased, category);
     }
 
     @GetMapping("/book/{bookId}")

--- a/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookMapper.java
@@ -22,9 +22,10 @@ public interface BookMapper {
     List<Book> findAll();
 
     @SelectProvider(BookSqlProvider.class)
-    List<Book> findBy(@Param("category") String category,
-                      @Param("name") String name,
-                      @Param("isPurchased") Boolean isPurchased);
+    List<Book> findBy(@Param("name") String name,
+                      @Param("releaseDate") String releaseDate,
+                      @Param("isPurchased") Boolean isPurchased,
+                      @Param("category") String category);
 
     @Select("select * from books join categories on books.category_id = categories.category_id where book_id = #{bookId}")
     Optional<Book> findByBookId(int bookId);

--- a/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
@@ -8,22 +8,26 @@ import org.apache.ibatis.jdbc.SQL;
 import java.time.LocalDate;
 
 public class BookSqlProvider implements ProviderMethodResolver {
-    public String findBy(@Param("category") String category,
-                         @Param("name") String name,
-                         @Param("isPurchased") Boolean isPurchased) {
+    public String findBy(@Param("name") String name,
+                         @Param("releaseDate") String releaseDate,
+                         @Param("isPurchased") Boolean isPurchased,
+                         @Param("category") String category) {
         return new SQL() {
             {
                 SELECT("*");
                 FROM("books");
                 JOIN("categories on books.category_id = categories.category_id");
-                if (category != null && !category.isEmpty()) {
-                    WHERE("category like concat('%',#{category},'%')");
-                }
                 if (name != null && !name.isEmpty()) {
                     WHERE("name like concat('%',#{name},'%')");
                 }
+                if (releaseDate != null && !releaseDate.isBlank()) {
+                    WHERE("release_date like concat('%',#{releaseDate},'%')");
+                }
                 if (isPurchased != null) {
                     WHERE("is_purchased = #{isPurchased}");
+                }
+                if (category != null && !category.isEmpty()) {
+                    WHERE("category like concat('%',#{category},'%')");
                 }
             }
         }.toString();
@@ -55,7 +59,7 @@ public class BookSqlProvider implements ProviderMethodResolver {
             }
         }.toString();
     }
-    
+
     public String updateBook(Book book) {
         return new SQL() {
             {

--- a/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
+++ b/src/main/java/com/ookawara/book/application/mapper/BookSqlProvider.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.builder.annotation.ProviderMethodResolver;
 import org.apache.ibatis.jdbc.SQL;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 public class BookSqlProvider implements ProviderMethodResolver {
     public String findBy(@Param("name") String name,
@@ -20,7 +21,7 @@ public class BookSqlProvider implements ProviderMethodResolver {
                 if (name != null && !name.isEmpty()) {
                     WHERE("name like concat('%',#{name},'%')");
                 }
-                if (releaseDate != null && !releaseDate.isBlank()) {
+                if (Objects.nonNull(releaseDate) && !releaseDate.isBlank()) {
                     WHERE("release_date like concat('%',#{releaseDate},'%')");
                 }
                 if (isPurchased != null) {

--- a/src/main/java/com/ookawara/book/application/service/BookService.java
+++ b/src/main/java/com/ookawara/book/application/service/BookService.java
@@ -22,11 +22,11 @@ public class BookService {
         this.bookMapper = bookMapper;
     }
 
-    public List<Book> findBy(String category, String name, Boolean isPurchased) {
-        if (category.isEmpty() && name.isEmpty() && isPurchased == null) {
+    public List<Book> findBy(String name, String releaseDate, Boolean isPurchased, String category) {
+        if (name.isEmpty() && releaseDate.isEmpty() && isPurchased == null && category.isEmpty()) {
             return bookMapper.findAll();
         } else {
-            return bookMapper.findBy(category, name, isPurchased);
+            return bookMapper.findBy(name, releaseDate, isPurchased, category);
         }
     }
 

--- a/src/main/java/com/ookawara/book/application/util/DateTimeFormat.java
+++ b/src/main/java/com/ookawara/book/application/util/DateTimeFormat.java
@@ -20,10 +20,29 @@ public class DateTimeFormat {
             try {
                 return LocalDate.parse(format, DateTimeFormatter.ofPattern("uuuu/MM/dd").withResolverStyle(ResolverStyle.STRICT));
             } catch (DateTimeParseException e) {
-                throw new DateFormatException("yyyy/MM/dd の形式（例：2000/01/01）で存在する日付を入力してください。");
+                throw new DateFormatException("YYYY/MM/DD の形式（例：2000/01/01）で存在する日付を入力してください。");
             }
         } else {
             return null;
+        }
+    }
+
+    public String getFormatCheck() {
+        if (format != null && !format.isBlank()) {
+            if (format.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) {
+                try {
+                    LocalDate localDateFormat = LocalDate.parse(format, DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT));
+                    return localDateFormat.format(DateTimeFormatter.ofPattern("uuuu-MM-dd"));
+                } catch (DateTimeParseException e) {
+                    throw new DateFormatException("存在する日付を入力してください。");
+                }
+            } else if (format.matches("^[0-9]{4}-[0-9]{2}$") || format.matches("^[0-9]{4}$")) {
+                return format;
+            } else {
+                throw new DateFormatException("YYYY-MM-DD の形式（例：2000-01-01）で年か、年月か、年月日を指定してください。");
+            }
+        } else {
+            return "";
         }
     }
 }

--- a/src/main/java/com/ookawara/book/application/util/DateTimeFormat.java
+++ b/src/main/java/com/ookawara/book/application/util/DateTimeFormat.java
@@ -31,8 +31,11 @@ public class DateTimeFormat {
         if (format != null && !format.isBlank()) {
             if (format.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")) {
                 try {
-                    LocalDate localDateFormat = LocalDate.parse(format, DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT));
-                    return localDateFormat.format(DateTimeFormatter.ofPattern("uuuu-MM-dd"));
+                    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd");
+                    LocalDate localDateFormat = dateTimeFormatter
+                            .withResolverStyle(ResolverStyle.STRICT)
+                            .parse(format, LocalDate::from);
+                    return localDateFormat.format(dateTimeFormatter);
                 } catch (DateTimeParseException e) {
                     throw new DateFormatException("存在する日付を入力してください。");
                 }

--- a/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
+++ b/src/test/java/com/ookawara/book/application/mapper/BookMapperTest.java
@@ -64,22 +64,8 @@ class BookMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
-    void 指定した文字列を含むカテゴリーに該当する全ての本のデータを取得() {
-        List<Book> books = bookMapper.findBy("ノ", "", null);
-        assertThat(books)
-                .hasSize(1)
-                .containsOnly(new Book(1, "ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2, "ライトノベル"));
-    }
-
-    @Test
-    @Sql(
-            scripts = {"classpath:/sqlannotation/delete-categories.sql", "classpath:/sqlannotation/insert-categories.sql",
-                    "classpath:/sqlannotation/delete-books.sql", "classpath:/sqlannotation/insert-books.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
-    @Transactional
     void 指定した文字列を含む書籍名に該当する全ての本のデータを取得() {
-        List<Book> books = bookMapper.findBy("", "の", null);
+        List<Book> books = bookMapper.findBy("の", "", null, null);
         assertThat(books)
                 .hasSize(2)
                 .containsOnly(
@@ -94,8 +80,23 @@ class BookMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
+    void 指定した文字列を含む発売日に該当する全ての本のデータを取得() {
+        List<Book> books = bookMapper.findBy("", "2016-06", null, null);
+        assertThat(books)
+                .hasSize(1)
+                .containsOnly(
+                        new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"));
+    }
+
+    @Test
+    @Sql(
+            scripts = {"classpath:/sqlannotation/delete-categories.sql", "classpath:/sqlannotation/insert-categories.sql",
+                    "classpath:/sqlannotation/delete-books.sql", "classpath:/sqlannotation/insert-books.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
     void 購入済みの全ての本のデータを取得() {
-        List<Book> books = bookMapper.findBy("", "", true);
+        List<Book> books = bookMapper.findBy("", "", true, null);
         assertThat(books)
                 .hasSize(2)
                 .containsOnly(
@@ -111,7 +112,7 @@ class BookMapperTest {
     )
     @Transactional
     void 未購入の全ての本のデータを取得() {
-        List<Book> books = bookMapper.findBy("", "", false);
+        List<Book> books = bookMapper.findBy("", "", false, null);
         assertThat(books)
                 .hasSize(1)
                 .containsOnly(new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"));
@@ -124,8 +125,23 @@ class BookMapperTest {
             executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
     )
     @Transactional
+    void 指定した文字列を含むカテゴリーに該当する全ての本のデータを取得() {
+        List<Book> books = bookMapper.findBy("", "", null, "小");
+        assertThat(books)
+                .hasSize(1)
+                .containsOnly(
+                        new Book(3, "ビブリア古書堂の事件手帖・1", LocalDate.of(2011, 3, 25), true, 3, "小説"));
+    }
+
+    @Test
+    @Sql(
+            scripts = {"classpath:/sqlannotation/delete-categories.sql", "classpath:/sqlannotation/insert-categories.sql",
+                    "classpath:/sqlannotation/delete-books.sql", "classpath:/sqlannotation/insert-books.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
     void 全てにnullを指定したときsql文の条件により全ての本のデータを返すこと() {
-        List<Book> books = bookMapper.findBy(null, null, null);
+        List<Book> books = bookMapper.findBy(null, null, null, null);
         assertThat(books)
                 .hasSize(3)
                 .containsOnly(
@@ -137,8 +153,8 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void カテゴリーに空文字を書籍名と購入状況にnullを指定したときsql文の条件により全ての本のデータを返すこと() {
-        List<Book> books = bookMapper.findBy("", null, null);
+    void 書籍名に空文字をその他の項目ににnullを指定したとき全ての本のデータを返すこと() {
+        List<Book> books = bookMapper.findBy("", null, null, null);
         assertThat(books)
                 .hasSize(3)
                 .containsOnly(
@@ -150,8 +166,8 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 書籍名に空文字をカテゴリーと購入状況にnullを指定したときsql文の条件により全ての本のデータを返すこと() {
-        List<Book> books = bookMapper.findBy(null, "", null);
+    void 発売日に空文字をその他の項目にnullを指定したときに全ての本のデータを返すこと() {
+        List<Book> books = bookMapper.findBy(null, "", null, null);
         assertThat(books)
                 .hasSize(3)
                 .containsOnly(
@@ -163,8 +179,8 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 書籍名とカテゴリーに空文字を購入状況にnullを指定したときsql文の条件により全ての本のデータを返すこと() {
-        List<Book> books = bookMapper.findBy("", "", null);
+    void 発売日に半角スペースのみをその他の項目にnullを指定したときに全ての本のデータを返すこと() {
+        List<Book> books = bookMapper.findBy("", " ", null, null);
         assertThat(books)
                 .hasSize(3)
                 .containsOnly(
@@ -176,16 +192,21 @@ class BookMapperTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void カテゴリーに存在しない文字列を指定したとき空のデータを返すこと() {
-        List<Book> books = bookMapper.findBy(" ", "", null);
-        assertThat(books).isEmpty();
+    void カテゴリーに空文字をその他の項目にnullを指定したときに全ての本のデータを返すこと() {
+        List<Book> books = bookMapper.findBy(null, null, null, "");
+        assertThat(books)
+                .hasSize(3)
+                .containsOnly(
+                        new Book(1, "ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2, "ライトノベル"),
+                        new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"),
+                        new Book(3, "ビブリア古書堂の事件手帖・1", LocalDate.of(2011, 3, 25), true, 3, "小説"));
     }
 
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void 書籍名に存在しない文字列を指定したとき空のデータを返すこと() {
-        List<Book> books = bookMapper.findBy("", " ", null);
+    void 存在しない文字列を指定したとき空のデータを返すこと() {
+        List<Book> books = bookMapper.findBy("あ", "9999-99-99", null, "1");
         assertThat(books).isEmpty();
     }
 

--- a/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
+++ b/src/test/java/com/ookawara/book/application/service/BookServiceTest.java
@@ -42,20 +42,9 @@ class BookServiceTest {
                 new Book(3, "ビブリア古書堂の事件手帖・1", LocalDate.of(2011, 3, 25), true, 3, "小説"));
 
         doReturn(allBooks).when(bookMapper).findAll();
-        List<Book> actual = bookService.findBy("", "", null);
+        List<Book> actual = bookService.findBy("", "", null, "");
         assertThat(actual).isEqualTo(allBooks);
         verify(bookMapper).findAll();
-    }
-
-    @Test
-    public void 指定した文字列を含むカテゴリーに該当する全ての本のデータを取得() {
-        List<Book> allBooks = List.of(
-                new Book(1, "ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2, "ライトノベル"));
-
-        doReturn(allBooks).when(bookMapper).findBy("ラ", "", null);
-        List<Book> actual = bookService.findBy("ラ", "", null);
-        assertThat(actual).isEqualTo(allBooks);
-        verify(bookMapper).findBy("ラ", "", null);
     }
 
     @Test
@@ -64,10 +53,21 @@ class BookServiceTest {
                 new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"),
                 new Book(3, "ビブリア古書堂の事件手帖・1", LocalDate.of(2011, 3, 25), true, 3, "小説"));
 
-        doReturn(allBooks).when(bookMapper).findBy("", "の", null);
-        List<Book> actual = bookService.findBy("", "の", null);
+        doReturn(allBooks).when(bookMapper).findBy("の", "", null, "");
+        List<Book> actual = bookService.findBy("の", "", null, "");
         assertThat(actual).isEqualTo(allBooks);
-        verify(bookMapper).findBy("", "の", null);
+        verify(bookMapper).findBy("の", "", null, "");
+    }
+
+    @Test
+    public void 指定した文字列を含む発売日に該当する全ての本のデータを取得() {
+        List<Book> allBooks = List.of(
+                new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"));
+
+        doReturn(allBooks).when(bookMapper).findBy("", "2016-06", null, "");
+        List<Book> actual = bookService.findBy("", "2016-06", null, "");
+        assertThat(actual).isEqualTo(allBooks);
+        verify(bookMapper).findBy("", "2016-06", null, "");
     }
 
     @Test
@@ -76,10 +76,10 @@ class BookServiceTest {
                 new Book(1, "ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2, "ライトノベル"),
                 new Book(3, "ビブリア古書堂の事件手帖・1", LocalDate.of(2011, 3, 25), true, 3, "小説"));
 
-        doReturn(allBooks).when(bookMapper).findBy("", "", true);
-        List<Book> actual = bookService.findBy("", "", true);
+        doReturn(allBooks).when(bookMapper).findBy("", "", true, null);
+        List<Book> actual = bookService.findBy("", "", true, null);
         assertThat(actual).isEqualTo(allBooks);
-        verify(bookMapper).findBy("", "", true);
+        verify(bookMapper).findBy("", "", true, null);
     }
 
     @Test
@@ -87,20 +87,31 @@ class BookServiceTest {
         List<Book> allBooks = List.of(
                 new Book(2, "鬼滅の刃・1", LocalDate.of(2016, 6, 8), false, 1, "漫画"));
 
-        doReturn(allBooks).when(bookMapper).findBy("", "", false);
-        List<Book> actual = bookService.findBy("", "", false);
+        doReturn(allBooks).when(bookMapper).findBy("", "", false, null);
+        List<Book> actual = bookService.findBy("", "", false, null);
         assertThat(actual).isEqualTo(allBooks);
-        verify(bookMapper).findBy("", "", false);
+        verify(bookMapper).findBy("", "", false, null);
+    }
+
+    @Test
+    public void 指定した文字列を含むカテゴリーに該当する全ての本のデータを取得() {
+        List<Book> allBooks = List.of(
+                new Book(1, "ノーゲーム・ノーライフ・1", LocalDate.of(2012, 4, 30), true, 2, "ライトノベル"));
+
+        doReturn(allBooks).when(bookMapper).findBy(" ", "", null, "ラ");
+        List<Book> actual = bookService.findBy(" ", "", null, "ラ");
+        assertThat(actual).isEqualTo(allBooks);
+        verify(bookMapper).findBy(" ", "", null, "ラ");
     }
 
     @Test
     public void 指定した文字列を含むデータが存在しないとき空のデータを返す() {
         List<Book> allBooks = List.of(new Book[0]);
 
-        doReturn(allBooks).when(bookMapper).findBy("no", " ", null);
-        List<Book> actual = bookService.findBy("no", " ", null);
+        doReturn(allBooks).when(bookMapper).findBy("no", " ", null, "い");
+        List<Book> actual = bookService.findBy("no", " ", null, "い");
         assertThat(actual).isEqualTo(allBooks);
-        verify(bookMapper).findBy("no", " ", null);
+        verify(bookMapper).findBy("no", " ", null, "い");
     }
 
     @Test

--- a/src/test/java/integrationtest/BookRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/BookRestApiIntegrationTest.java
@@ -72,27 +72,6 @@ class BookRestApiIntegrationTest {
     @Test
     @DataSet("datasets/books.yml")
     @Transactional
-    void クエリパラメーターで指定した文字列を含むカテゴリーに該当する全ての本のデータを取得できること() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/books?category=ノ"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().json("""
-                        [
-                           {
-                               "bookId": 1,
-                               "name": "ノーゲーム・ノーライフ・1",
-                               "releaseDate": 2012-04-30,
-                               "isPurchased": true,
-                               "categoryId": 2,
-                               "category": "ライトノベル"
-                           }
-                        ]
-                        """
-                ));
-    }
-
-    @Test
-    @DataSet("datasets/books.yml")
-    @Transactional
     void クエリパラメーターで指定した文字列を含む書籍名に該当する全ての本のデータを取得できること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/books?name=の"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -117,6 +96,107 @@ class BookRestApiIntegrationTest {
                         ]
                         """
                 ));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void クエリパラメーターで指定した文字列の年月日を含む発売日に該当する全ての本のデータを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/books?releaseDate=2016-06-08"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                               "bookId": 2,
+                               "name": "鬼滅の刃・1",
+                               "releaseDate": 2016-06-08,
+                               "isPurchased": false,
+                               "categoryId": 1,
+                               "category": "漫画"
+                           }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void クエリパラメーターで指定した文字列の年月日が存在しない日付のときに400が返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/books?releaseDate=2021-02-29"))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                {
+                    "timestamp": "2024-01-01 00:00:00.000000+09:00[Asia/Tokyo]",
+                    "status": "400",
+                    "error": "Bad Request",
+                    "message": "存在する日付を入力してください。",
+                    "path": "/books"
+                }
+                """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true
+        )));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void クエリパラメーターで指定した文字列の年月を含む発売日に該当する全ての本のデータを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/books?releaseDate=2016-06"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                               "bookId": 2,
+                               "name": "鬼滅の刃・1",
+                               "releaseDate": 2016-06-08,
+                               "isPurchased": false,
+                               "categoryId": 1,
+                               "category": "漫画"
+                           }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void クエリパラメーターで指定した文字列の年を含む発売日に該当する全ての本のデータを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/books?releaseDate=2016"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                               "bookId": 2,
+                               "name": "鬼滅の刃・1",
+                               "releaseDate": 2016-06-08,
+                               "isPurchased": false,
+                               "categoryId": 1,
+                               "category": "漫画"
+                           }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void クエリパラメーターで指定した文字列の発売日が指定されたフォーマットではないときに400が返されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/books?releaseDate=2021/02/29"))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                {
+                    "timestamp": "2024-01-01 00:00:00.000000+09:00[Asia/Tokyo]",
+                    "status": "400",
+                    "error": "Bad Request",
+                    "message": "YYYY-MM-DD の形式（例：2000-01-01）で年か、年月か、年月日を指定してください。",
+                    "path": "/books"
+                }
+                """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true
+        )));
     }
 
     @Test
@@ -163,6 +243,27 @@ class BookRestApiIntegrationTest {
                                "isPurchased": false,
                                "categoryId": 1,
                                "category": "漫画"
+                           }
+                        ]
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @Transactional
+    void クエリパラメーターで指定した文字列を含むカテゴリーに該当する全ての本のデータを取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/books?category=ノ"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                               "bookId": 1,
+                               "name": "ノーゲーム・ノーライフ・1",
+                               "releaseDate": 2012-04-30,
+                               "isPurchased": true,
+                               "categoryId": 2,
+                               "category": "ライトノベル"
                            }
                         ]
                         """
@@ -497,7 +598,7 @@ class BookRestApiIntegrationTest {
                     "timestamp": "2024-01-01 00:00:00.000000+09:00[Asia/Tokyo]",
                     "status": "400",
                     "error": "Bad Request",
-                    "message": "yyyy/MM/dd の形式（例：2000/01/01）で存在する日付を入力してください。",
+                    "message": "YYYY/MM/DD の形式（例：2000/01/01）で存在する日付を入力してください。",
                     "path": "/books/2"
                 }
                 """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", (o1, o2) -> true


### PR DESCRIPTION
# 概要
・API仕様書とREADMEとの齟齬がないように機能の修正・追加等確認をしています。

・クエリパラメータで発売日を検索する機能を追加しました。
・Mapper のfindby メソッドの引数を変更したため変更ファイル数が多くなっています。
・API仕様書で発売日のフォーマットをYYYY -MM-DD としているため入力時のフォーマットチェックを行う処理も追加しました。