### PR TITLE
結合テストに更新時のテストを新たに追加

### DIFF
--- a/src/test/java/integrationtest/BookRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/BookRestApiIntegrationTest.java
@@ -508,12 +508,55 @@ class BookRestApiIntegrationTest {
     @DataSet("datasets/books.yml")
     @ExpectedDataSet(value = "datasets/update/update-books-name.yml")
     @Transactional
-    void 書籍名のみ正常に更新できること() throws Exception {
+    void 書籍データが1項目のみでも正常に更新できること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.patch("/books/2")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
                                     "name": "鬼滅の刃 1"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "正常に更新されました"
+                        }
+                        """));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @ExpectedDataSet(value = "datasets/update/update-books-twoColumns.yml")
+    @Transactional
+    void 書籍データが2項目のみでも正常に更新できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/books/2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "鬼滅の刃 1",
+                                    "releaseDate": "2016/07/08"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "正常に更新されました"
+                        }
+                        """));
+    }
+
+    @Test
+    @DataSet("datasets/books.yml")
+    @ExpectedDataSet(value = "datasets/update/update-books-threeColumns.yml")
+    @Transactional
+    void 書籍データが3項目のみでも正常に更新できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/books/2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "鬼滅の刃 1",
+                                    "releaseDate": "2016/07/08",
+                                    "isPurchased": true
                                 }
                                 """))
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/resources/datasets/update/update-books-threeColumns.yml
+++ b/src/test/resources/datasets/update/update-books-threeColumns.yml
@@ -1,0 +1,16 @@
+books:
+  - book_id: 1
+    name: "ノーゲーム・ノーライフ・1"
+    release_date: "2012-04-30"
+    is_purchased: 1
+    category_id: 2
+  - book_id: 2
+    name: "鬼滅の刃 1"
+    release_date: "2016-07-08"
+    is_purchased: 1
+    category_id: 1
+  - book_id: 3
+    name: "ビブリア古書堂の事件手帖・1"
+    release_date: "2011-03-25"
+    is_purchased: 1
+    category_id: 3

--- a/src/test/resources/datasets/update/update-books-twoColumns.yml
+++ b/src/test/resources/datasets/update/update-books-twoColumns.yml
@@ -1,0 +1,16 @@
+books:
+  - book_id: 1
+    name: "ノーゲーム・ノーライフ・1"
+    release_date: "2012-04-30"
+    is_purchased: 1
+    category_id: 2
+  - book_id: 2
+    name: "鬼滅の刃 1"
+    release_date: "2016-07-08"
+    is_purchased: 0
+    category_id: 1
+  - book_id: 3
+    name: "ビブリア古書堂の事件手帖・1"
+    release_date: "2011-03-25"
+    is_purchased: 1
+    category_id: 3


### PR DESCRIPTION
# 概要
・API仕様書に則って、結合テストに更新時の項目の数によって正常に更新処理がされるかのテストを新たに追加しました。